### PR TITLE
Allow to input custom image shape

### DIFF
--- a/resize_dataset/cfg/default.yaml
+++ b/resize_dataset/cfg/default.yaml
@@ -2,7 +2,7 @@ dataset_format: "coco"
 dataset_task: "panoptic"
 task: scale
 scale_factor: 4
-image_shape: null # or [H,W]
+image_shape: null # or [W,H]
 resize_image_method: "bicubic"
 resize_mask_method: "nearest"
 show: False

--- a/resize_dataset/dataset/base.py
+++ b/resize_dataset/dataset/base.py
@@ -58,6 +58,26 @@ class ResizableDataset(Dataset, ABC):
         """
 
     @abstractmethod
+    def reshape(self, img, anns, shape, resize_image_method):
+        """
+        Reshape an image and its associated annotations by a specified factor.
+
+        This function adjusts the size of the input image and modifies the annotations accordingly
+        to maintain their relevance after resizing. The image can be resized using different methods
+        specified by the user.
+
+        Args:
+            img (np.ndarray): The image to be scaled, represented as a NumPy array.
+            anns (list): A list of annotations associated with the image, which will also be scaled.
+            shape (tuple): The new shape of the image and annotations.
+            resize_image_method (str): The method used for resizing the image.
+
+        Returns:
+            tuple: A tuple containing the scaled image (np.ndarray)
+                and the modified annotations (list).
+        """
+
+    @abstractmethod
     def show(self, image, anns):
         """
         Displays an image along with its associated annotations.

--- a/resize_dataset/dataset/coco.py
+++ b/resize_dataset/dataset/coco.py
@@ -220,6 +220,66 @@ class COCODataset(ResizableDataset):
             ann["area"] *= scale_factor**2
         return img, anns
 
+    def reshape(self, img, anns, shape, resize_image_method="bicubic"):
+        """
+        Reshapes an image and its corresponding annotations to a specified size.
+
+        This function resizes the input image and scales the bounding boxes and
+        segmentation annotations according to the new dimensions. It offers the
+        option to specify the method used for resizing the image.
+
+        Args:
+            img (np.ndarray): The input image to be resized.
+            anns (list[dict]): A list of annotations corresponding to the image,
+                each containing at least a "bbox" key and optionally "segmentation".
+            shape (tuple): The desired output shape of the image as (width, height).
+            resize_image_method (str, optional): The method used for resizing the
+                image, default is "bicubic". Other methods can be defined in
+                RESIZE_METHODS.
+
+        Returns:
+            tuple: A tuple containing the resized image (np.ndarray) and the updated
+            annotations (list[dict]).
+        """
+        h0, w0 = img.shape[:2]
+        wn, hn = shape
+        xf = wn / w0
+        yf = hn / h0
+        img = RESIZE_METHODS.get(resize_image_method)(img, shape)
+        for ann in anns:
+            x1, y1, w, h = ann["bbox"]
+            ann["bbox"] = [x1 * xf, y1 * yf, w * xf, h * yf]
+            if "segmentation" in ann:
+                if isinstance(ann["segmentation"], list):  # Segmentation polygon
+                    for i, polygon in enumerate(ann["segmentation"]):
+                        ann["segmentation"][i] = [
+                            c * xf if i % 2 == 0 else c * yf
+                            for i, c in enumerate(polygon)
+                        ]
+                else:
+                    seg = ann["segmentation"]
+                    h0, w0 = seg["size"]
+                    xf = wn / w0
+                    yf = hn / h0
+                    if isinstance(ann["segmentation"]["counts"], str):
+                        mask = mask_utils.decode(ann["segmentation"])
+                    else:
+                        mask = rle_to_mask(seg["counts"], h0, w0, order="F")
+                    resized_mask = cv2.resize(
+                        mask, shape, interpolation=cv2.INTER_NEAREST
+                    ).astype(np.uint8)
+                    if isinstance(ann["segmentation"]["counts"], str):
+                        ann["segmentation"]["counts"] = binary_mask_to_rle_coded(
+                            resized_mask
+                        )
+                    else:
+                        ann["segmentation"]["counts"] = mask_to_rle(
+                            resized_mask, order="F"
+                        )
+                    ann["segmentation"]["size"] = [hn, wn]
+            ann["area"] *= xf * yf
+        return img, anns
+
     def save(self, index, image, anns):
         """
         Saves an image and its annotations to the output folder and dictionary.
@@ -239,8 +299,15 @@ class COCODataset(ResizableDataset):
         img_ann = self.annotations.imgs[img_id]
         cv2.imwrite(str(Path(self.images_output_folder) / img_ann["file_name"]), image)
         self.output_annotations["annotations"].append(anns)
-        img_ann["width"] *= self.cfg.scale_factor
-        img_ann["height"] *= self.cfg.scale_factor
+        if self.cfg.image_shape is None:
+            sfx = self.cfg.scale_factor
+            sfy = self.cfg.scale_factor
+        else:
+            wn, hn = self.cfg.image_shape
+            sfx = wn / img_ann["width"]
+            sfy = hn / img_ann["height"]
+        img_ann["width"] *= sfx
+        img_ann["height"] *= sfy
         self.output_annotations["images"].append(img_ann)
 
     def show(self, image, anns):
@@ -325,10 +392,15 @@ class COCODataset(ResizableDataset):
         anns = [self.annotations.anns[idx] for idx in ann_ids]
         path = self.annotations.imgs[img_id]["file_name"]
         img = cv2.imread(str(Path(self.images_folder) / path))
-        img, anns = self.scale(
+        resize_function, resize_parameter = (
+            (self.scale, self.cfg.scale_factor)
+            if self.cfg.image_shape is None
+            else (self.reshape, self.cfg.image_shape)
+        )
+        img, anns = resize_function(
             img,
             anns,
-            scale_factor=self.cfg.scale_factor,
+            resize_parameter,
             resize_image_method=self.cfg.resize_image_method,
         )
         if self.cfg.save:
@@ -499,6 +571,43 @@ class COCODatasetPanoptic(ResizableDataset):
             seg_info["area"] *= scale_factor**2
         return img, (anns, scaled_segmentation)
 
+    def reshape(self, img, anns, shape, resize_image_method="bicubic"):
+        """
+        Reshapes an image and its corresponding segmentation annotations to a specified size.
+
+        This function resizes the input image using a specified interpolation method
+        and adjusts the corresponding segmentation annotations to match the new dimensions.
+
+        Args:
+            img (np.ndarray): The input image to be resized.
+            anns (dict): The annotations corresponding to the image, including
+                segmentation information.
+            shape (tuple): The desired shape for the output image as (width, height).
+            resize_image_method (str, optional): The method to use for resizing the image
+                (default is "bicubic").
+
+        Returns:
+            tuple: A tuple containing the resized image (np.ndarray) and a tuple of updated
+                annotations (dict) along with the resized segmentation mask (np.ndarray).
+        """
+        h0, w0 = img.shape[:2]
+        wn, hn = shape
+        xf = wn / w0
+        yf = hn / h0
+        img = RESIZE_METHODS.get(resize_image_method)(img, shape)
+        seg_path = str(self.annotations_folder / anns["file_name"])
+        seg_img = cv2.imread(seg_path, cv2.IMREAD_COLOR)
+        scaled_segmentation = cv2.resize(
+            seg_img,
+            shape,
+            interpolation=cv2.INTER_NEAREST,
+        )
+        for seg_info in anns["segments_info"]:
+            x1, y1, w, h = seg_info["bbox"]
+            seg_info["bbox"] = [x1 * xf, y1 * yf, w * xf, h * yf]
+            seg_info["area"] *= xf * yf
+        return img, (anns, scaled_segmentation)
+
     def save(self, index, image, anns):
         """
         Saves an image and its annotations to the output folders and dictionary.
@@ -525,8 +634,15 @@ class COCODatasetPanoptic(ResizableDataset):
             scaled_mask,
         )
         self.output_annotations["annotations"].append(annotation)
-        img_ann["width"] *= self.cfg.scale_factor
-        img_ann["height"] *= self.cfg.scale_factor
+        if self.cfg.image_shape is None:
+            sfx = self.cfg.scale_factor
+            sfy = self.cfg.scale_factor
+        else:
+            wn, hn = self.cfg.image_shape
+            sfx = wn / img_ann["width"]
+            sfy = hn / img_ann["height"]
+        img_ann["width"] *= sfx
+        img_ann["height"] *= sfy
         self.output_annotations["images"].append(img_ann)
 
     def show(self, image, anns):
@@ -593,10 +709,15 @@ class COCODatasetPanoptic(ResizableDataset):
         img_info = self.annotations.imgs[img_id]
         img = cv2.imread(str(Path(self.images_folder) / img_info["file_name"]))
         anns = self.annotations.anns[img_id]
-        img, anns = self.scale(
+        resize_function, resize_parameter = (
+            (self.scale, self.cfg.scale_factor)
+            if self.cfg.image_shape is None
+            else (self.reshape, self.cfg.image_shape)
+        )
+        img, anns = resize_function(
             img,
             anns,
-            scale_factor=self.cfg.scale_factor,
+            resize_parameter,
             resize_image_method=self.cfg.resize_image_method,
         )
         if self.cfg.save:

--- a/resize_dataset/image/resize.py
+++ b/resize_dataset/image/resize.py
@@ -1,22 +1,89 @@
+from typing import overload, Union, Tuple
 import cv2
+import numpy as np
 from resize_dataset.utils import ConfigDict
 
+RESIZE_METHODS = ConfigDict()
 
-def resize_image_bicubic(image, scale):
+
+def infer_type_and_load_arguments(
+    *args, **kwargs
+) -> Tuple[str, np.ndarray, Union[int, float, Tuple[int, int]]]:
     """
-    Resizes an image using bicubic interpolation.
-
-    This function takes an image and a scaling factor, then resizes the image to
-    the specified scale using bicubic interpolation, which produces smoother results
-    compared to other interpolation methods.
+    Infers the type of operation (resize or scale) and loads arguments accordingly.
 
     Args:
-        image (numpy.ndarray): The input image to be resized,
-            expected in height x width x channels format.
-        scale (float): The scaling factor to resize the image.
+        *args: Positional arguments which can be an image, and optionally shape or scale.
+        **kwargs: Keyword arguments which can include 'image', 'shape', and 'scale'.
 
     Returns:
-        numpy.ndarray: The resized image with the new dimensions.
+        tuple: A tuple containing:
+            - function_type (str): The type of operation ('resize' or 'scale').
+            - image (np.ndarray): The image to be processed.
+            - other (Union[int, float, tuple]): The scale or shape for resizing.
+
+    Raises:
+        ValueError: If required parameters are missing or if both shape and scale are provided.
+        TypeError: If input types are incorrect.
+    """
+    if len(args) == 1:
+        image = args[0]
+        if not isinstance(image, np.ndarray):
+            raise TypeError("The image should be a numpy ndarray.")
+    elif len(args) == 2:
+        image, other = args
+        if not isinstance(image, np.ndarray):
+            raise TypeError("The image should be a numpy ndarray.")
+        if isinstance(other, (list, tuple, np.ndarray)):
+            function_type = "resize"
+        elif isinstance(other, (int, float)):
+            function_type = "scale"
+        else:
+            raise TypeError(
+                "The second argument must be a list, tuple, ndarray, int, or float."
+            )
+        return function_type, image, other
+    elif len(args) == 0:
+        image = kwargs.get("image", None)
+        if image is None:
+            raise ValueError("Image parameter missing!")
+        if not isinstance(image, np.ndarray):
+            raise TypeError("The image should be a numpy ndarray.")
+    else:
+        raise ValueError("Invalid number of arguments provided.")
+    shape = kwargs.get("shape", None)
+    scale = kwargs.get("scale", None)
+    if shape is not None:
+        function_type = "resize"
+        other = shape
+        if not isinstance(shape, (tuple, list)):
+            raise TypeError("Shape must be a tuple or list.")
+    elif scale is not None:
+        function_type = "scale"
+        other = scale
+        if not isinstance(scale, (int, float)):
+            raise TypeError("Scale must be an int or float.")
+    else:
+        raise ValueError("Scale or shape parameter missing!")
+    return function_type, image, other
+
+
+@overload
+def resize_image_bicubic(image: np.ndarray, scale: Union[float, int]) -> np.ndarray: ...
+@overload
+def resize_image_bicubic(image: np.ndarray, size: Tuple[int, int]) -> np.ndarray: ...
+
+
+def _scale_image_bicubic(image: np.ndarray, scale: Union[float, int]) -> np.ndarray:
+    """
+    Scales an image using bicubic interpolation.
+
+    Args:
+        image (np.ndarray): The image to be scaled.
+        scale (Union[float, int]): The scale factor.
+
+    Returns:
+        np.ndarray: The scaled image.
     """
     h, w = image.shape[:2]
     return cv2.resize(
@@ -24,4 +91,34 @@ def resize_image_bicubic(image, scale):
     )
 
 
-RESIZE_METHODS = ConfigDict(bicubic=resize_image_bicubic)
+def _reshape_image_bicubic(image: np.ndarray, shape: Tuple[int, int]) -> np.ndarray:
+    """
+    Reshapes an image to the given dimensions using bicubic interpolation.
+
+    Args:
+        image (np.ndarray): The image to be reshaped.
+        shape (tuple): The target dimensions (width, height).
+
+    Returns:
+        np.ndarray: The reshaped image.
+    """
+    return cv2.resize(image, shape, interpolation=cv2.INTER_CUBIC)
+
+
+@RESIZE_METHODS.register(name="bicubic")
+def resize_image_bicubic(*args, **kwargs) -> np.ndarray:
+    """
+    Resizes or scales an image using bicubic interpolation.
+
+    Args:
+        *args: Positional arguments which can be an image, and optionally shape or scale.
+        **kwargs: Keyword arguments which can include 'image', 'shape', and 'scale'.
+
+    Returns:
+        np.ndarray: The resized or scaled image.
+    """
+    function_type, image, other = infer_type_and_load_arguments(*args, **kwargs)
+    if function_type == "scale":
+        return _scale_image_bicubic(image, other)
+    else:
+        return _reshape_image_bicubic(image, other)


### PR DESCRIPTION
## Summary
This PR allows the resizing of the images and labels of the dataset based on custom input shape.

## Description
Implementation includes:
- base.py: Added the `reshape` abstract method
- coco.py: Modified the `__getitem__` and `save` methods of all the datasets, and added `reshape` methods.
- default.yaml: Modified order of `input_shape`, from [H,W] to [W,H].
- resize.py: Modified `resize_image_bicubic` to input image_shape or scale, depending on the type of the input parameters. 